### PR TITLE
Revert "Bump version: 1.4.0 → 1.5.0"

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.0
+current_version = 1.4.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/dapla/__init__.py
+++ b/dapla/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.0"
+__version__ = "1.4.0"
 
 from .auth import AuthClient
 from .backports import details, show

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-toolbelt"
-version = "1.5.0"
+version = "1.4.0"
 description = "Python module for use within Jupyterlab notebooks, specifically aimed for Statistics Norway's data platform called Dapla"
 authors = ["Statistics Norway <stat-dev@ssb.no>"]
 license = "MIT"


### PR DESCRIPTION
Reverts statisticsnorway/dapla-toolbelt#50

Release was not triggered by last pr.