### PR TITLE
Bump version: 1.7.1 → 1.8.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.1
+current_version = 1.8.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/dapla/__init__.py
+++ b/dapla/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.7.1"
+__version__ = "1.8.0"
 
 from .auth import AuthClient
 from .backports import details, show

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-toolbelt"
-version = "1.7.1"
+version = "1.8.0"
 description = "Python module for use within Jupyterlab notebooks, specifically aimed for Statistics Norway's data platform called Dapla"
 authors = ["Statistics Norway <stat-dev@ssb.no>"]
 license = "MIT"


### PR DESCRIPTION
I didn't read the `README.md` carefully enough and forgot to bump the version before merging to main. This PR fixes this.