### PR TITLE
Changed so remove gcs uri prefix checks the list if list

### DIFF
--- a/dapla/pandas.py
+++ b/dapla/pandas.py
@@ -32,7 +32,12 @@ def read_pandas(
         fs = FileClient.get_gcs_file_system()
 
         # Workaround for https://github.com/apache/arrow/issues/30481
-        gcs_path = FileClient._remove_gcs_uri_prefix(gcs_path)
+        if isinstance(gcs_path, list):
+            gcs_path = [
+                FileClient._remove_gcs_uri_prefix(file) for file in gcs_path
+                       ]
+        else:
+            gcs_path = FileClient._remove_gcs_uri_prefix(gcs_path)
 
         parquet_ds = pq.ParquetDataset(
             gcs_path,


### PR DESCRIPTION
I found out that I had overlooked something. The read_pandas didnt work with list because remove_gcs_uri_prefix was checking a string and not the strings in the list. A small adjustment is now added. sorry about this!