### PR TITLE
Remove TestPyPI from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,11 @@ jobs:
         if: steps.check-version.outputs.tag
         uses: pypa/gh-action-pypi-publish@v1.8.11
 
-      - name: Publish package on TestPyPI
-        if: "! steps.check-version.outputs.tag"
-        uses: pypa/gh-action-pypi-publish@v1.8.11
-        with:
-          repository-url: https://test.pypi.org/legacy/
+      #- name: Publish package on TestPyPI We don't have the login to the TestPyPi org
+      #  if: "! steps.check-version.outputs.tag"
+      #  uses: pypa/gh-action-pypi-publish@v1.8.11
+      #  with:
+      #    repository-url: https://test.pypi.org/legacy/
 
       - name: Publish the release notes
         uses: release-drafter/release-drafter@v5.25.0


### PR DESCRIPTION
We don't have access to the TestPyPI account, and so we cannot set up "Trusted Publisher" on that account. Removing the repository meanwhile.