### PR TITLE
Loosen requirements on 'pandas-stubs'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-toolbelt"
-version = "2.0.0"
+version = "2.0.1"
 description = "Dapla Toolbelt"
 authors = ["Dapla Developers <dapla-platform-developers@ssb.no>"]
 license = "MIT"


### PR DESCRIPTION
- Loosen requirements on 'pandas-stubs' to be able to deploy on JupyterHub
- Add release 2.0.1
