### PR TITLE
Tighten Pyarrow version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ python = ">=3.10,<4.0"
 click = ">=8.0.1"
 types-requests = ">=2.28.11"
 requests = ">=2.27.1"
-pyarrow = ">=8.0.0"
+pyarrow = ">=14.0.2, <15" # This tight constraint is dependent on fixing https://issues.apache.org/jira/browse/ARROW-7867
 pydantic = ">=1.9.1"
 pandas = ">=1.4.2"
 gcsfs = ">=2022.7.1"


### PR DESCRIPTION
We use a workaround for Spark to be able to use the GCSFileSystem-class. This workaround is described in the code [here](https://github.com/statisticsnorway/dapla-toolbelt/blob/29d8560d44e2b89db314a78db89b966c52bb931c/src/dapla/gcs.py#L16). However, ParquetManifest (as described in the code) was removed in PyArrow v15. This PR tightens the version constraint on PyArrow to be able to keep using the workaround. Obviously, this is not ideal and should be investigated further at some point.