### PR TITLE
Remove extraneous arg

### DIFF
--- a/src/dapla/pandas.py
+++ b/src/dapla/pandas.py
@@ -86,7 +86,6 @@ def read_pandas(
             parquet_ds = pq.ParquetDataset(
                 gcs_path,
                 filesystem=fs,
-                use_legacy_dataset=False,
                 filters=filters,  # type: ignore [arg-type]
             )  # Stubs show the incorrect type -
             # see https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetDataset.html


### PR DESCRIPTION
This argument is default=False anyway, and the arg is deprecated and will be removed soon. Also quells a deprecation warning
