### PR TITLE
Send payload to Maskinporten Guardian as json

### DIFF
--- a/src/dapla/guardian.py
+++ b/src/dapla/guardian.py
@@ -77,7 +77,7 @@ class GuardianClient:
                 "Authorization": "Bearer %s" % keycloak_token,
                 "Content-type": "application/json",
             },
-            data=body,
+            json=body,
         )
         if guardian_response.status_code == 200:
             return t.cast(str, guardian_response.json()["accessToken"])


### PR DESCRIPTION
In order to use the "data" param we have to convert the payload to JSON ourselves (e.g. using json.dumps) Instead, requests have a dedicated json param that handles this for us

Resolves #149