### PR TITLE
Fix auth refresh argument

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dapla-toolbelt"
-version = "3.0.0"
+version = "3.0.1"
 description = "Dapla Toolbelt"
 authors = ["Dapla Developers <dapla-platform-developers@ssb.no>"]
 license = "MIT"


### PR DESCRIPTION
When refreshing the Google token in Jupyter, the default argument 'from_jupyterhub' was not appropriately passed.
